### PR TITLE
feat: add HOST env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,5 +10,6 @@ NEXT_PUBLIC_GRAPHQL_URL=http://localhost:8080/v1/graphql
 NEXT_PUBLIC_GRAPHQL_WS=ws://localhost:8080/v1/graphql
 NODE_ENV=development
 PORT=3000
+HOST=::
 NEXT_PUBLIC_RPC_WEBSOCKET=http://localhost:26657/websocket
 NEXT_PUBLIC_CHAIN_TYPE=testnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Removed the use of NEXT_PUBLIC_URL
 - Update graphql types generation structure (in preparation for third party modules)
 - Update preview image location
+- Added `HOST` env var
 
 # base-v2.1.0 - 2021-04-19
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ const app = next({
 const handle = app.getRequestHandler();
 
 const port = process.env.PORT || 3000;
+const host = process.env.HOST || "::";
 
 (async () => {
   try {
@@ -29,12 +30,13 @@ const port = process.env.PORT || 3000;
     server.all('*', (req: Request, res: Response) => {
       return handle(req, res);
     });
-    server.listen(port, (err?: any) => {
+    server.listen(port, host, (err?: any) => {
       if (err) throw err;
       console.log('> Blast Off Ready On:');
       console.log(`> URL: http://localhost:${port}`);
       console.log(`> ENV: ${process.env.NODE_ENV || 'development'}`);
       console.log(`> PORT: ${port}`);
+      console.log(`> HOST: ${host}`);
     });
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In a similar vein as https://github.com/forbole/bdjuno/issues/449, I am having a problem where there is no way to configure the Big Dipper UI server to only listen on loopback (`127.0.0.1`) instead of globally. This leaves my server with an open non-TLS port, when I'd rather have that port closed off to the world. In my setup I am using nginx to reverse-proxy big dipper, so I am running Big Dipper on port 3001, and ideally only ports 80 and 443 would be open on my server.

This PR fixes this issue by having a `HOST` env var that allows hosting on `127.0.0.1`.


## Checklist
- [x] Ran Linting
- [x] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [x] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
