### PR TITLE
ci: Skip ui task when no change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.vars.outputs.matrix }}
+      uiHasChanged: ${{ steps.vars.outputs.uiHasChanged }}
       webHasChanged: ${{ steps.vars.outputs.webHasChanged }}
       cacheDirectory: ${{ steps.vars.outputs.cacheDirectory }}
     steps:
@@ -49,6 +50,10 @@ jobs:
             jq -crM '{ project: [ .[] | select( . | startswith(\"web-\") ) ] }'
           ) | tee -a $GITHUB_OUTPUT $GITHUB_STEP_SUMMARY
 
+          echo 'uiHasChanged='$(
+            [ $(echo $PACKAGES  | jq -crM 'index(\"ui\")') = \"null\" ] && echo no || echo yes
+          ) | tee -a $GITHUB_OUTPUT $GITHUB_STEP_SUMMARY
+
           echo 'webHasChanged='$(
             [ $(echo $PACKAGES  | jq -crM 'index(\"web\")') = \"null\" ] && echo no || echo yes
           ) | tee -a $GITHUB_OUTPUT $GITHUB_STEP_SUMMARY
@@ -57,7 +62,7 @@ jobs:
             npx jest --showConfig | jq -cr '.configs[0].cacheDirectory'
           ) | tee -a $GITHUB_OUTPUT"
   ui:
-    if: ${{ success() }}
+    if: ${{ success() && needs.install.outputs.uiHasChanged == 'yes' }}
     needs: install
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

- if no change had been made, the tasks for `ui` workspace can be skipped in github actions

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] ran linting
- [X] wrote tests where necessary
- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] targeted the correct branch
- [X] provided a link to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed
- [X] added an entry to the `CHANGELOG.md` file
