### PR TITLE
feat: Inject Runtime Config on Dockerfile

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,10 +6,10 @@
 # See the README for full descriptions of each of the
 # available configurations.
 
-GRAPHQL_URL=http://localhost:8080/v1/graphql
-GRAPHQL_WS=ws://localhost:8080/v1/graphql
+NEXT_PUBLIC_GRAPHQL_URL=http://localhost:8080/v1/graphql
+NEXT_PUBLIC_GRAPHQL_WS=ws://localhost:8080/v1/graphql
 NODE_ENV=development
 PORT=3000
-RPC_WEBSOCKET=http://localhost:26657/websocket
-NEXT_PUBLIC_CHAIN_TYPE=mainnet
+NEXT_PUBLIC_RPC_WEBSOCKET=http://localhost:26657/websocket
+NEXT_PUBLIC_CHAIN_TYPE=
 PROJECT_NAME=web

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,7 +43,9 @@ jobs:
           node <<EOF
           const { writeFileSync } = require('fs');
           const projectName = process.env.PROJECT_NAME || 'web';
-          const chainType = process.env.NEXT_PUBLIC_CHAIN_TYPE || 'mainnet';
+          let chainType = process.env.NEXT_PUBLIC_CHAIN_TYPE;
+          if (!chainType) chainType = 'mainnet';
+          chainType = chainType.toLowerCase();
           const config = {
             buildCommand: 'NEXT_PUBLIC_CHAIN_TYPE=' + chainType + ' BASE_PATH=${{ github.event.inputs.base_path }} yarn turbo run build --filter=' + projectName + '...',
             outputDirectory: 'apps/' + projectName + '/.next',

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,9 @@ jobs:
           # assign chain_type
           node <<EOF
           const { appendFileSync } = require('fs');
-          const chainType = (process.env.NEXT_PUBLIC_CHAIN_TYPE || 'mainnet').toLowerCase();
+          let chainType = process.env.NEXT_PUBLIC_CHAIN_TYPE;
+          if (!chainType) chainType = 'mainnet';
+          chainType = chainType.toLowerCase();
           const chainJson = require('./apps/' + process.env.PROJECT_NAME + '/src/chain.json');
           const { chains, ...settings } = chainJson;
           let chain = chains.find((c) => c.chainType?.toLowerCase() === chainType);

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,9 @@ COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/.next/apps/$
 RUN printf 'const { readFileSync, writeFileSync } = require("fs");\n\
 function inject(file) {\n\
   const code = readFileSync(file, "utf8")\n\
-    .replace(/(['"'"'"`])[{][{](\
+    .replace(/(['\
+"'"\
+'"`])[{][{](\
 NEXT_PUBLIC_CHAIN_TYPE|\
 NEXT_PUBLIC_BANNERS_JSON|\
 NEXT_PUBLIC_GRAPHQL_URL|\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 ARG BASE_IMAGE=node:18
 ARG PROJECT_NAME=web
-ARG RUNTIME=yarn
 
 # Stage: pruner
 FROM ${BASE_IMAGE} AS pruner
@@ -54,6 +53,44 @@ ENV TURBO_TEAM=${TURBO_TEAM}
 ARG TURBO_TOKEN
 ENV TURBO_TOKEN=${TURBO_TOKEN}
 ENV BUILD_STANDALONE=1
+ENV NEXT_PUBLIC_CHAIN_TYPE={{NEXT_PUBLIC_CHAIN_TYPE}}
+ENV NEXT_PUBLIC_BANNERS_JSON={{NEXT_PUBLIC_BANNERS_JSON}}
+ENV NEXT_PUBLIC_GRAPHQL_URL={{NEXT_PUBLIC_GRAPHQL_URL}}
+ENV NEXT_PUBLIC_GRAPHQL_WS={{NEXT_PUBLIC_GRAPHQL_WS}}
+ENV NEXT_PUBLIC_MATOMO_URL={{NEXT_PUBLIC_MATOMO_URL}}
+ENV NEXT_PUBLIC_MATOMO_SITE_ID={{NEXT_PUBLIC_MATOMO_SITE_ID}}
+ENV NEXT_PUBLIC_RPC_WEBSOCKET={{NEXT_PUBLIC_RPC_WEBSOCKET}}
+RUN SENTRYCLI_SKIP_DOWNLOAD=$([ -z "${NEXT_PUBLIC_SENTRY_DSN}" ] && echo 1) \
+  yarn workspaces focus --production ${PROJECT_NAME} && \
+  yarn add typescript -D
+
+## Build the project
+COPY --from=pruner /app/out/full/ ./
+RUN turbo run build --filter=${PROJECT_NAME}...
+
+################################################################################
+
+ARG RIPGREP=ripgrep_13.0.0_amd64.deb
+
+# Stage: web
+FROM ${BASE_IMAGE} AS web
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs && \
+  adduser --system --uid 1001 nextjs && \
+  chown -R nextjs:nodejs /home/nextjs /app
+ 
+# Copying the files from the builder stage to the web stage.
+ARG PROJECT_NAME
+ENV PROJECT_NAME=${PROJECT_NAME}
+COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/.next/apps/${PROJECT_NAME}/.next/ ./.next/
+COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/.next/static/ ./.next/static/
+COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/public/ ./public/
+COPY --chown=nextjs:nodejs --from=builder /app/node_modules/ ./node_modules/
+COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/.next/apps/${PROJECT_NAME}/server.js ./
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 ARG NEXT_PUBLIC_CHAIN_TYPE
 ENV NEXT_PUBLIC_CHAIN_TYPE=${NEXT_PUBLIC_CHAIN_TYPE}
 ARG NEXT_PUBLIC_BANNERS_JSON
@@ -68,41 +105,44 @@ ARG NEXT_PUBLIC_MATOMO_SITE_ID
 ENV NEXT_PUBLIC_MATOMO_SITE_ID=${NEXT_PUBLIC_MATOMO_SITE_ID}
 ARG NEXT_PUBLIC_RPC_WEBSOCKET
 ENV NEXT_PUBLIC_RPC_WEBSOCKET=${NEXT_PUBLIC_RPC_WEBSOCKET}
-RUN SENTRYCLI_SKIP_DOWNLOAD=$([ -z "${NEXT_PUBLIC_SENTRY_DSN}" ] && echo 1) \
-  yarn workspaces focus --production ${PROJECT_NAME} && \
-  yarn add typescript -D
-
-## Build the project
-COPY --from=pruner /app/out/full/ ./
-RUN turbo run build --filter=${PROJECT_NAME}...
-
-################################################################################
-
-# Stage: web
-FROM ${BASE_IMAGE} AS web
-WORKDIR /app
-
-RUN addgroup --system --gid 1001 nodejs && \
-  adduser --system --uid 1001 nextjs && \
-  chown -R nextjs:nodejs /home/nextjs
 
 # Don't run production as root
 USER nextjs
- 
-# Copying the files from the builder stage to the web stage.
-ARG PROJECT_NAME
-ENV PROJECT_NAME=${PROJECT_NAME}
-COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/.next/apps/${PROJECT_NAME}/.next/ ./.next/
-COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/.next/static/ ./.next/static/
-COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/public/ ./public/
-COPY --chown=nextjs:nodejs --from=builder /app/node_modules/ ./node_modules/
-COPY --chown=nextjs:nodejs --from=builder /app/apps/${PROJECT_NAME}/.next/apps/${PROJECT_NAME}/server.js ./
 
-ENV NODE_ENV=production
-ENV NEXT_TELEMETRY_DISABLED=1
+# reference: https://github.com/vercel/next.js/discussions/34894
+RUN printf 'const { readFileSync, writeFileSync } = require("fs");\n\
+function inject(file) {\n\
+  const code = readFileSync(file, "utf8")\n\
+    .replace(/(['"'"'"`])[{][{](\
+NEXT_PUBLIC_CHAIN_TYPE|\
+NEXT_PUBLIC_BANNERS_JSON|\
+NEXT_PUBLIC_GRAPHQL_URL|\
+NEXT_PUBLIC_GRAPHQL_WS|\
+NEXT_PUBLIC_MATOMO_URL|\
+NEXT_PUBLIC_MATOMO_SITE_ID|\
+NEXT_PUBLIC_RPC_WEBSOCKET\
+)[}][}]\\1/gi\
+, (match, quote, name) => {\n\
+  console.log(`inject ${match} with ${JSON.stringify(process.env[name.toUpperCase()])} in ${file}`);\n\
+  return JSON.stringify(process.env[name] ?? "")\n\
+});\n\
+  writeFileSync(file, code, "utf8");\n\
+}\n' > ./inject.js && \
+  egrep -ilr \
+  '[{][{](\
+NEXT_PUBLIC_CHAIN_TYPE|\
+NEXT_PUBLIC_BANNERS_JSON|\
+NEXT_PUBLIC_GRAPHQL_URL|\
+NEXT_PUBLIC_GRAPHQL_WS|\
+NEXT_PUBLIC_MATOMO_URL|\
+NEXT_PUBLIC_MATOMO_SITE_ID|\
+NEXT_PUBLIC_RPC_WEBSOCKET\
+)[}][}]' \
+  ./.next | \
+  xargs -I{} printf 'inject("'{}'");\n' | tee -a ./inject.js
 
 ARG PORT=3000
 ENV PORT=${PORT}
-EXPOSE ${PORT:-3000}
+EXPOSE ${PORT}
 
-CMD node /app/server.js
+CMD node /app/inject.js && node /app/server.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ ENV TURBO_TEAM=${TURBO_TEAM}
 ARG TURBO_TOKEN
 ENV TURBO_TOKEN=${TURBO_TOKEN}
 ENV BUILD_STANDALONE=1
+# add placeholder for env variables to be injected in Stage: web
 ENV NEXT_PUBLIC_CHAIN_TYPE={{NEXT_PUBLIC_CHAIN_TYPE}}
 ENV NEXT_PUBLIC_BANNERS_JSON={{NEXT_PUBLIC_BANNERS_JSON}}
 ENV NEXT_PUBLIC_GRAPHQL_URL={{NEXT_PUBLIC_GRAPHQL_URL}}
@@ -69,8 +70,6 @@ COPY --from=pruner /app/out/full/ ./
 RUN turbo run build --filter=${PROJECT_NAME}...
 
 ################################################################################
-
-ARG RIPGREP=ripgrep_13.0.0_amd64.deb
 
 # Stage: web
 FROM ${BASE_IMAGE} AS web

--- a/apps/web-agoric/jest.setup.ts
+++ b/apps/web-agoric/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-agoric/package.json
+++ b/apps/web-agoric/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-agoric/sentry.client.config.ts
+++ b/apps/web-agoric/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-agoric/sentry.server.config.ts
+++ b/apps/web-agoric/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-akash/jest.setup.ts
+++ b/apps/web-akash/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-akash/package.json
+++ b/apps/web-akash/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-akash/sentry.client.config.ts
+++ b/apps/web-akash/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-akash/sentry.server.config.ts
+++ b/apps/web-akash/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-assetmantle/jest.setup.ts
+++ b/apps/web-assetmantle/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-assetmantle/package.json
+++ b/apps/web-assetmantle/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-assetmantle/sentry.client.config.ts
+++ b/apps/web-assetmantle/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-assetmantle/sentry.server.config.ts
+++ b/apps/web-assetmantle/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-band/jest.setup.ts
+++ b/apps/web-band/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-band/package.json
+++ b/apps/web-band/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-band/sentry.client.config.ts
+++ b/apps/web-band/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-band/sentry.server.config.ts
+++ b/apps/web-band/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-bitsong/jest.setup.ts
+++ b/apps/web-bitsong/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-bitsong/package.json
+++ b/apps/web-bitsong/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-bitsong/sentry.client.config.ts
+++ b/apps/web-bitsong/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-bitsong/sentry.server.config.ts
+++ b/apps/web-bitsong/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-comdex/jest.setup.ts
+++ b/apps/web-comdex/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-comdex/package.json
+++ b/apps/web-comdex/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-comdex/sentry.client.config.ts
+++ b/apps/web-comdex/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-comdex/sentry.server.config.ts
+++ b/apps/web-comdex/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-cosmos/jest.setup.ts
+++ b/apps/web-cosmos/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-cosmos/package.json
+++ b/apps/web-cosmos/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-cosmos/sentry.client.config.ts
+++ b/apps/web-cosmos/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-cosmos/sentry.server.config.ts
+++ b/apps/web-cosmos/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-crescent/jest.setup.ts
+++ b/apps/web-crescent/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-crescent/package.json
+++ b/apps/web-crescent/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-crescent/sentry.client.config.ts
+++ b/apps/web-crescent/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-crescent/sentry.server.config.ts
+++ b/apps/web-crescent/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-desmos/jest.setup.ts
+++ b/apps/web-desmos/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-desmos/package.json
+++ b/apps/web-desmos/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-desmos/sentry.client.config.ts
+++ b/apps/web-desmos/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-desmos/sentry.server.config.ts
+++ b/apps/web-desmos/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-elrond/jest.setup.ts
+++ b/apps/web-elrond/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-elrond/package.json
+++ b/apps/web-elrond/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-elrond/sentry.client.config.ts
+++ b/apps/web-elrond/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-elrond/sentry.server.config.ts
+++ b/apps/web-elrond/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-elrond/src/screens/node_details/components/profile/index.tsx
+++ b/apps/web-elrond/src/screens/node_details/components/profile/index.tsx
@@ -35,12 +35,12 @@ const Profile: React.FC<{ profile: ProfileType; showRating: boolean } & Componen
 
   let validator = null;
 
-  if (props.profile.validator) {
+  if (props.profile?.validator) {
     validator = (
       <div className="detail">
-        <Link href={VALIDATOR_DETAILS(props.profile.identity)} passHref>
+        <Link href={VALIDATOR_DETAILS(props.profile?.identity)} passHref>
           <Typography variant="body1" className="value" component="a">
-            {getMiddleEllipsis(props.profile.validator, ellipsis)}
+            {getMiddleEllipsis(props.profile?.validator, ellipsis)}
           </Typography>
         </Link>
       </div>
@@ -60,13 +60,13 @@ const Profile: React.FC<{ profile: ProfileType; showRating: boolean } & Componen
       <div className={classes.topWrapper}>
         <div className={classes.nametag}>
           <Typography variant="h2" className="name">
-            {props.profile.name}
+            {props.profile?.name}
           </Typography>
-          <Typography className="version">({props.profile.version})</Typography>
+          <Typography className="version">({props.profile?.version})</Typography>
         </div>
         {!!props.showRating && (
           <Typography className={classes.rating}>
-            {t('rating')} {props.profile.rating}%
+            {t('rating')} {props.profile?.rating}%
           </Typography>
         )}
       </div>
@@ -78,11 +78,11 @@ const Profile: React.FC<{ profile: ProfileType; showRating: boolean } & Componen
           </Typography>
           <div className="detail">
             <CopyIcon
-              onClick={() => handleCopyToClipboard(props.profile.pubkey)}
+              onClick={() => handleCopyToClipboard(props.profile?.pubkey)}
               className={classes.actionIcons}
             />
             <Typography variant="body1" className="value">
-              {getMiddleEllipsis(props.profile.pubkey, ellipsis)}
+              {getMiddleEllipsis(props.profile?.pubkey, ellipsis)}
             </Typography>
           </div>
         </div>

--- a/apps/web-emoney/jest.setup.ts
+++ b/apps/web-emoney/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-emoney/package.json
+++ b/apps/web-emoney/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-emoney/sentry.client.config.ts
+++ b/apps/web-emoney/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-emoney/sentry.server.config.ts
+++ b/apps/web-emoney/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-evmos/jest.setup.ts
+++ b/apps/web-evmos/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-evmos/package.json
+++ b/apps/web-evmos/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-evmos/sentry.client.config.ts
+++ b/apps/web-evmos/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-evmos/sentry.server.config.ts
+++ b/apps/web-evmos/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-likecoin/jest.setup.ts
+++ b/apps/web-likecoin/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-likecoin/package.json
+++ b/apps/web-likecoin/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-likecoin/sentry.client.config.ts
+++ b/apps/web-likecoin/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-likecoin/sentry.server.config.ts
+++ b/apps/web-likecoin/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-nomic/jest.setup.ts
+++ b/apps/web-nomic/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-nomic/package.json
+++ b/apps/web-nomic/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-nomic/sentry.client.config.ts
+++ b/apps/web-nomic/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-nomic/sentry.server.config.ts
+++ b/apps/web-nomic/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-nomic/src/screens/account_details/utils.tsx
+++ b/apps/web-nomic/src/screens/account_details/utils.tsx
@@ -1,11 +1,17 @@
-import axios from 'axios';
+import chainConfig from '@/chainConfig';
 import {
   AccountBalancesDocument,
   // AccountWithdrawalAddressDocument,
   AccountDelegationBalanceDocument,
 } from '@/graphql/general/account_details_documents';
+import axios from 'axios';
 
-import chainConfig from '@/chainConfig';
+function getUrl() {
+  let url = process.env.NEXT_PUBLIC_GRAPHQL_URL;
+  if (!url) url = chainConfig().endpoints.graphql;
+  if (!url) url = 'http://localhost:3000/v1/graphql';
+  return url;
+}
 
 export const fetchAvailableBalances = async (address: string) => {
   const defaultReturnValue = {
@@ -14,17 +20,12 @@ export const fetchAvailableBalances = async (address: string) => {
     },
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          address,
-        },
-        query: AccountBalancesDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        address,
+      },
+      query: AccountBalancesDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;
@@ -38,17 +39,12 @@ export const fetchAvailableBalances = async (address: string) => {
 //     },
 //   };
 //   try {
-//     const { data } = await axios.post(
-//       process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-//         chainConfig().endpoints.graphql ||
-//         'http://localhost:3000/v1/graphql',
-//       {
-//         variables: {
-//           address,
-//         },
-//         query: AccountWithdrawalAddressDocument,
-//       }
-//     );
+//     const { data } = await axios.post(getUrl(), {
+//       variables: {
+//         address,
+//       },
+//       query: AccountWithdrawalAddressDocument,
+//     });
 //     return data?.data ?? defaultReturnValue;
 //   } catch (error) {
 //     return defaultReturnValue;
@@ -62,17 +58,12 @@ export const fetchDelegationBalance = async (address: string) => {
     },
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          address,
-        },
-        query: AccountDelegationBalanceDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        address,
+      },
+      query: AccountDelegationBalanceDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;

--- a/apps/web-nym/jest.setup.ts
+++ b/apps/web-nym/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-nym/package.json
+++ b/apps/web-nym/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-nym/sentry.client.config.ts
+++ b/apps/web-nym/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-nym/sentry.server.config.ts
+++ b/apps/web-nym/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-osmosis/jest.setup.ts
+++ b/apps/web-osmosis/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-osmosis/package.json
+++ b/apps/web-osmosis/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-osmosis/sentry.client.config.ts
+++ b/apps/web-osmosis/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-osmosis/sentry.server.config.ts
+++ b/apps/web-osmosis/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-persistence/jest.setup.ts
+++ b/apps/web-persistence/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-persistence/package.json
+++ b/apps/web-persistence/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-persistence/sentry.client.config.ts
+++ b/apps/web-persistence/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-persistence/sentry.server.config.ts
+++ b/apps/web-persistence/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-provenance/jest.setup.ts
+++ b/apps/web-provenance/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-provenance/package.json
+++ b/apps/web-provenance/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-provenance/sentry.client.config.ts
+++ b/apps/web-provenance/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-provenance/sentry.server.config.ts
+++ b/apps/web-provenance/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-regen/jest.setup.ts
+++ b/apps/web-regen/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-regen/package.json
+++ b/apps/web-regen/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-regen/sentry.client.config.ts
+++ b/apps/web-regen/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-regen/sentry.server.config.ts
+++ b/apps/web-regen/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-rizon/jest.setup.ts
+++ b/apps/web-rizon/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-rizon/package.json
+++ b/apps/web-rizon/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-rizon/sentry.client.config.ts
+++ b/apps/web-rizon/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-rizon/sentry.server.config.ts
+++ b/apps/web-rizon/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-shentu/jest.setup.ts
+++ b/apps/web-shentu/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-shentu/package.json
+++ b/apps/web-shentu/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-shentu/sentry.client.config.ts
+++ b/apps/web-shentu/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-shentu/sentry.server.config.ts
+++ b/apps/web-shentu/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-sifchain/jest.setup.ts
+++ b/apps/web-sifchain/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-sifchain/package.json
+++ b/apps/web-sifchain/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-sifchain/sentry.client.config.ts
+++ b/apps/web-sifchain/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-sifchain/sentry.server.config.ts
+++ b/apps/web-sifchain/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-stride/jest.setup.ts
+++ b/apps/web-stride/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web-stride/package.json
+++ b/apps/web-stride/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web-stride/sentry.client.config.ts
+++ b/apps/web-stride/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web-stride/sentry.server.config.ts
+++ b/apps/web-stride/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Changes
+
+- Allow docker image to change config based on runtime environment variables ([\#1064](https://github.com/forbole/big-dipper-2.0-cosmos/issues/1064))
+
 # main-v2.2.0 - 2022-11-22
 
 ## Changes
@@ -31,7 +35,7 @@
 - Updated graphql types generation structure (in preparation for third party modules)
 - Updated preview image location
 - Updated change url files ([\#972](https://github.com/forbole/big-dipper-2.0-cosmos/issues/972))
-- Added `MATOMO_URL` and `MATOMO_SITE_ID` to github workflow production ([\#972](https://github.com/forbole/big-dipper-2.0-cosmos/issues/972))
+- Added `NEXT_PUBLIC_MATOMO_URL` and `NEXT_PUBLIC_MATOMO_SITE_ID` to github workflow production ([\#972](https://github.com/forbole/big-dipper-2.0-cosmos/issues/972))
 
 # base-v2.1.0 - 2022-04-19
 
@@ -83,12 +87,12 @@
 
 ## Changes
 
-- Changed `NEXT_PUBLIC_WS_CHAIN_URL` to `RPC_WEBSOCKET` for clarification
+- Changed `NEXT_PUBLIC_WS_CHAIN_URL` to `NEXT_PUBLIC_RPC_WEBSOCKET` for clarification
 - Changed `NEXT_PUBLIC_CHAIN_STATUS` to `NEXT_PUBLIC_CHAIN_TYPE` for clarification
 
 ## Migration
 
-- Changed env `NEXT_PUBLIC_WS_CHAIN_URL` to `RPC_WEBSOCKET` or don't. It's backwards compatible
+- Changed env `NEXT_PUBLIC_WS_CHAIN_URL` to `NEXT_PUBLIC_RPC_WEBSOCKET` or don't. It's backwards compatible
 - Changed env `NEXT_PUBLIC_CHAIN_STATUS` to `NEXT_PUBLIC_CHAIN_TYPE` or don't. It's backwards compatible
 
 ## Breaking

--- a/apps/web/jest.setup.ts
+++ b/apps/web/jest.setup.ts
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -3,8 +3,6 @@ import chainConfig from '@/chainConfig';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import chainConfig from '@/chainConfig';
 
 Sentry.init({
-  release: `${chainConfig().chainName}-${chainConfig().chainType}@${
-    process.env.npm_package_version
-  }`,
+  release: `${chainConfig().chainName}@${process.env.npm_package_version}`,
   tracesSampleRate: 1.0,
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,33 @@
 version: "3.8"
+x-web: &web
+  build:
+    context: .
+    args:
+      PROJECT_NAME: ${PROJECT_NAME:-web}
+      NEXT_PUBLIC_CHAIN_TYPE: ${NEXT_PUBLIC_CHAIN_TYPE:-}
+      TURBO_TEAM: ${TURBO_TEAM:-}
+      TURBO_TOKEN: ${TURBO_TOKEN:-}
+      PORT: ${PORT:-3000}
+      NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
+      SENTRY_AUTH_TOKEN: ${SENTRY_AUTH_TOKEN:-}
+    target: web
+  restart: always
+  platform: linux/amd64
+  volumes:
+    - yarn-cache:/root/.yarn/berry/cache:rw
+  ports:
+    - ${PORT:-3000}:${PORT:-3000}
+  networks:
+    - app_network
 services:
-  web:
+  # default web
+  web: *web
+  # for mac with M1/M2 chip
+  web-arm64v8:
+    <<: *web
     build:
-      context: .
       args:
-        PROJECT_NAME: ${PROJECT_NAME:-web}
-        NEXT_PUBLIC_CHAIN_TYPE: ${NEXT_PUBLIC_CHAIN_TYPE:-mainnet}
-        TURBO_TEAM: ${TURBO_TEAM:-}
-        TURBO_TOKEN: ${TURBO_TOKEN:-}
-        PORT: ${PORT:-3000}
-        NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
-        SENTRY_AUTH_TOKEN: ${SENTRY_AUTH_TOKEN:-}
-      target: web
-    restart: always
-    platform: linux/amd64
-    volumes:
-      - yarn-cache:/root/.yarn/berry/cache:rw
-    ports:
-      - ${PORT:-3000}:${PORT:-3000}
-    networks:
-      - app_network
+        BASE_IMAGE: arm64v8/node:18
 # Define a network, which allows containers to communicate
 # with each other, by using their container name as a hostname
 networks:

--- a/packages/ui/jest.setup.ts
+++ b/packages/ui/jest.setup.ts
@@ -1,7 +1,7 @@
 import 'jest-localstorage-mock';
 
 jest.mock('@/chainConfig', () => () => {
-  const { default: chainConfig }: { default: { tokenUnits: object } } =
+  const { default: chainConfig }: { default(): { tokenUnits: object } } =
     jest.requireActual('@/chainConfig');
   const config = chainConfig();
   config.tokenUnits = {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,7 +45,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "react-window-infinite-loader": "^1.0.8",
-    "recharts": "^2.1.16",
+    "recharts": "^2.2.0",
     "recoil": "^0.7.6",
     "shared-utils": "*",
     "sharp": "^0.31.2",

--- a/packages/ui/src/chainConfig/index.ts
+++ b/packages/ui/src/chainConfig/index.ts
@@ -1,9 +1,11 @@
-import type { ChainConfig } from '@/chainConfig/types';
 import chainJson from '@/chain.json';
+import type { ChainConfig } from '@/chainConfig/types';
 
 function chainConfig() {
   /* Setting the basePath, chainType, chains, and settings variables. */
-  const chainType = (process.env.NEXT_PUBLIC_CHAIN_TYPE || 'mainnet').toLowerCase();
+  let chainType = process.env.NEXT_PUBLIC_CHAIN_TYPE;
+  if (!chainType) chainType = 'mainnet';
+  chainType = chainType.toLowerCase();
   const { chains, ...settings } = chainJson;
   let chain = chains.find((c) => c.chainType?.toLowerCase() === chainType);
   if (!chain && chainType !== 'testnet') {

--- a/packages/ui/src/components/banner/index.tsx
+++ b/packages/ui/src/components/banner/index.tsx
@@ -1,8 +1,14 @@
+import { useStyles } from '@/components/banner/styles';
 import Box from '@/components/box';
+
 import Image from 'next/future/image';
 import Link from 'next/link';
 import { FC, useRef } from 'react';
-import { useStyles } from './styles';
+
+export interface BannerLink {
+  url: string;
+  img: string;
+}
 
 /**
  * It returns an array of objects with two properties, `title` and `url`, which are used to render the
@@ -10,11 +16,13 @@ import { useStyles } from './styles';
  * @returns An array of objects with a string key and a string value.
  */
 export function getBannersLinks() {
-  let bannerLinks: Array<{ url: string; img: string }> = [];
-  if (process.env.NEXT_PUBLIC_BANNERS_JSON) {
+  const bannersJson = process.env.NEXT_PUBLIC_BANNERS_JSON;
+  let bannerLinks: BannerLink[] = [];
+
+  if (bannersJson) {
     try {
-      const bannersJson = JSON.parse(process.env.NEXT_PUBLIC_BANNERS_JSON);
-      if (Array.isArray(bannersJson)) bannerLinks = bannersJson;
+      const bannersArray = JSON.parse(bannersJson);
+      if (Array.isArray(bannersArray)) bannerLinks = bannersArray;
     } catch (e) {
       // ignore
     }

--- a/packages/ui/src/components/msg/staking/delegate/index.tsx
+++ b/packages/ui/src/components/msg/staking/delegate/index.tsx
@@ -13,7 +13,7 @@ const Delegate: React.FC<{ message: MsgDelegate }> = (props) => {
 
   const validator = useProfileRecoil(message.validatorAddress);
   const validatorMoniker = validator ? validator?.name : message.validatorAddress;
-  const amount = formatToken(message.amount.amount, message.amount.denom);
+  const amount = formatToken(message.amount?.amount, message.amount?.denom);
 
   const parsedAmount = `${formatNumber(
     amount.value,

--- a/packages/ui/src/components/msg/staking/redelegate/index.tsx
+++ b/packages/ui/src/components/msg/staking/redelegate/index.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 const Redelegate: React.FC<{ message: MsgRedelegate }> = (props) => {
   const { message } = props;
-  const amount = formatToken(message.amount.amount, message.amount.denom);
+  const amount = formatToken(message.amount?.amount, message.amount?.denom);
 
   const parsedAmount = `${formatNumber(
     amount.value,

--- a/packages/ui/src/components/msg/staking/undelegate/index.tsx
+++ b/packages/ui/src/components/msg/staking/undelegate/index.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 const Undelegate: React.FC<{ message: MsgUndelegate }> = (props) => {
   const { message } = props;
-  const amount = formatToken(message.amount.amount, message.amount.denom);
+  const amount = formatToken(message.amount?.amount, message.amount?.denom);
 
   const parsedAmount = `${formatNumber(
     amount.value,

--- a/packages/ui/src/components/pagination/components/actions/index.tsx
+++ b/packages/ui/src/components/pagination/components/actions/index.tsx
@@ -65,7 +65,7 @@ const Actions: React.FC<Props> = (props) => {
           component="li"
           variant="body2"
           key={x}
-          onClick={() => onChangePage(null, x)}
+          onClick={() => onChangePage?.(null, x)}
           className={classnames(classes.button, classes.pageButton, {
             selected: page === x,
           })}

--- a/packages/ui/src/hooks/use_desmos_profile/index.ts
+++ b/packages/ui/src/hooks/use_desmos_profile/index.ts
@@ -41,7 +41,7 @@ export const useDesmosProfile = (options: Options) => {
         }
 
         // if the address is a link instead
-        if (!data.profile.length) {
+        if (!data.profile?.length) {
           data = await fetchLink(input);
         }
         setLoading(false);
@@ -112,7 +112,7 @@ async function fetchDtag(dtag: string) {
 }
 
 function formatDesmosProfile(data: DesmosProfileQuery): DesmosProfile | null {
-  if (!data.profile.length) {
+  if (!data.profile?.length) {
     return null;
   }
 

--- a/packages/ui/src/recoil/profiles/utils.tsx
+++ b/packages/ui/src/recoil/profiles/utils.tsx
@@ -43,7 +43,7 @@ async function fetchDesmosProfile(address: string) {
     }
 
     // if the address is a link instead
-    if (!data.profile.length) {
+    if (!data.profile?.length) {
       data = await fetchLink(address);
     }
 
@@ -55,7 +55,7 @@ async function fetchDesmosProfile(address: string) {
 }
 
 function formatDesmosProfile(data: DesmosProfileQuery) {
-  if (!data.profile.length) {
+  if (!data.profile?.length) {
     return null;
   }
 

--- a/packages/ui/src/screens/account_details/components/balance/utils.tsx
+++ b/packages/ui/src/screens/account_details/components/balance/utils.tsx
@@ -36,11 +36,13 @@ export const formatBalanceData = (data: {
     },
     {
       key: 'balanceReward',
-      display: `${formatNumber(
-        data.reward.value,
-        data.reward.exponent
-      )} ${data.reward.displayDenom.toUpperCase()}`,
-      value: data.reward.value,
+      display: data.reward
+        ? `${formatNumber(
+            data.reward.value,
+            data.reward.exponent
+          )} ${data.reward.displayDenom.toUpperCase()}`
+        : '',
+      value: data.reward?.value,
     },
   ];
 

--- a/packages/ui/src/screens/account_details/components/other_tokens/components/desktop/index.tsx
+++ b/packages/ui/src/screens/account_details/components/other_tokens/components/desktop/index.tsx
@@ -20,7 +20,7 @@ const Desktop: React.FC<{
     token: x.denom.toUpperCase(),
     commission: formatNumber(x.commission.value, x.commission.exponent),
     available: formatNumber(x.available.value, x.available.exponent),
-    reward: formatNumber(x.reward.value, x.reward.exponent),
+    reward: x.reward ? formatNumber(x.reward.value, x.reward.exponent) : '',
   }));
 
   return (

--- a/packages/ui/src/screens/account_details/components/other_tokens/components/mobile/index.tsx
+++ b/packages/ui/src/screens/account_details/components/other_tokens/components/mobile/index.tsx
@@ -17,7 +17,7 @@ const Mobile: React.FC<{
     <div className={classnames(className)}>
       {items?.map((x, i) => {
         const available = formatNumber(x.available.value, x.available.exponent);
-        const reward = formatNumber(x.reward.value, x.reward.exponent);
+        const reward = x.reward ? formatNumber(x.reward.value, x.reward.exponent) : '';
         const commission = formatNumber(x.commission.value, x.commission.exponent);
         return (
           // eslint-disable-next-line react/no-array-index-key

--- a/packages/ui/src/screens/account_details/components/staking/components/delegations/components/desktop/index.tsx
+++ b/packages/ui/src/screens/account_details/components/staking/components/delegations/components/desktop/index.tsx
@@ -17,8 +17,8 @@ const Desktop: React.FC<{
 }> = ({ className, items }) => {
   const { t } = useTranslation('accounts');
   const formattedItems = items?.map((x) => {
-    const amount = formatNumber(x.amount.value, x.amount.exponent);
-    const reward = formatNumber(x.reward.value, x.reward.exponent);
+    const amount = x.amount ? formatNumber(x.amount.value, x.amount.exponent) : '';
+    const reward = x.reward ? formatNumber(x.reward.value, x.reward.exponent) : '';
     return {
       validator: (
         <AvatarName
@@ -27,8 +27,8 @@ const Desktop: React.FC<{
           imageUrl={x.validator.imageUrl}
         />
       ),
-      amount: `${amount} ${x.amount.displayDenom.toUpperCase()}`,
-      reward: `${reward} ${x.reward.displayDenom.toUpperCase()}`,
+      amount: `${amount} ${x.amount?.displayDenom.toUpperCase()}`,
+      reward: `${reward} ${x.reward?.displayDenom.toUpperCase()}`,
     };
   });
 

--- a/packages/ui/src/screens/account_details/components/staking/components/delegations/components/mobile/index.tsx
+++ b/packages/ui/src/screens/account_details/components/staking/components/delegations/components/mobile/index.tsx
@@ -37,8 +37,8 @@ const Mobile: React.FC<{
                   {t('amount')}
                 </Typography>
                 <Typography variant="body1" className="value">
-                  {formatNumber(x.amount.value, x.amount.exponent)}{' '}
-                  {x.amount.displayDenom.toUpperCase()}
+                  {x.amount ? formatNumber(x.amount.value, x.amount.exponent) : ''}{' '}
+                  {x.amount?.displayDenom.toUpperCase()}
                 </Typography>
               </div>
               <div className={classes.item}>
@@ -46,8 +46,8 @@ const Mobile: React.FC<{
                   {t('reward')}
                 </Typography>
                 <Typography variant="body1" className="value">
-                  {formatNumber(x.reward.value, x.reward.exponent)}{' '}
-                  {x.reward.displayDenom.toUpperCase()}
+                  {x.reward ? formatNumber(x.reward.value, x.reward.exponent) : ''}{' '}
+                  {x.reward?.displayDenom.toUpperCase()}
                 </Typography>
               </div>
             </div>

--- a/packages/ui/src/screens/account_details/components/staking/components/redelegations/components/desktop/index.tsx
+++ b/packages/ui/src/screens/account_details/components/staking/components/redelegations/components/desktop/index.tsx
@@ -23,10 +23,9 @@ const Desktop: React.FC<{
   const formattedItems = items?.map((x) => ({
     to: <AvatarName address={x.to.address} imageUrl={x.to.imageUrl} name={x.to.name} />,
     from: <AvatarName address={x.from.address} imageUrl={x.from.imageUrl} name={x.from.name} />,
-    amount: `${formatNumber(
-      x.amount.value,
-      x.amount.exponent
-    )} ${x.amount.displayDenom.toUpperCase()}`,
+    amount: x.amount
+      ? `${formatNumber(x.amount.value, x.amount.exponent)} ${x.amount.displayDenom.toUpperCase()}`
+      : '',
     completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
   }));
 

--- a/packages/ui/src/screens/account_details/components/staking/components/redelegations/components/mobile/index.tsx
+++ b/packages/ui/src/screens/account_details/components/staking/components/redelegations/components/mobile/index.tsx
@@ -21,10 +21,9 @@ const Mobile: React.FC<{
   const formattedItems = items?.map((x) => ({
     to: <AvatarName address={x.to.address} imageUrl={x.to.imageUrl} name={x.to.name} />,
     from: <AvatarName address={x.from.address} imageUrl={x.from.imageUrl} name={x.from.name} />,
-    amount: `${formatNumber(
-      x.amount.value,
-      x.amount.exponent
-    )} ${x.amount.displayDenom.toUpperCase()}`,
+    amount: x.amount
+      ? `${formatNumber(x.amount.value, x.amount.exponent)} ${x.amount.displayDenom.toUpperCase()}`
+      : '',
     completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
   }));
 

--- a/packages/ui/src/screens/account_details/components/staking/components/unbondings/components/desktop/index.tsx
+++ b/packages/ui/src/screens/account_details/components/staking/components/unbondings/components/desktop/index.tsx
@@ -28,10 +28,9 @@ const Desktop: React.FC<{
         name={x.validator.name}
       />
     ),
-    amount: `${formatNumber(
-      x.amount.value,
-      x.amount.exponent
-    )} ${x.amount.displayDenom.toUpperCase()}`,
+    amount: x.amount
+      ? `${formatNumber(x.amount.value, x.amount.exponent)} ${x.amount.displayDenom.toUpperCase()}`
+      : '',
     completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
   }));
 

--- a/packages/ui/src/screens/account_details/components/staking/components/unbondings/components/mobile/index.tsx
+++ b/packages/ui/src/screens/account_details/components/staking/components/unbondings/components/mobile/index.tsx
@@ -26,10 +26,9 @@ const Mobile: React.FC<{
         name={x.validator.name}
       />
     ),
-    amount: `${formatNumber(
-      x.amount.value,
-      x.amount.exponent
-    )} ${x.amount.displayDenom.toUpperCase()}`,
+    amount: x.amount
+      ? `${formatNumber(x.amount.value, x.amount.exponent)} ${x.amount.displayDenom.toUpperCase()}`
+      : '',
     completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
   }));
 

--- a/packages/ui/src/screens/account_details/components/staking/hooks.ts
+++ b/packages/ui/src/screens/account_details/components/staking/hooks.ts
@@ -10,6 +10,7 @@ import { getDenom } from '@/utils/get_denom';
 import { Tabs } from '@material-ui/core';
 import axios from 'axios';
 import Big from 'big.js';
+
 import { useRouter } from 'next/router';
 import * as R from 'ramda';
 import { ComponentProps, useCallback, useEffect, useState } from 'react';
@@ -22,6 +23,13 @@ const stakingDefault = {
 
 const LIMIT = 100;
 const PAGE_LIMIT = 10;
+
+function getUrl() {
+  let url = process.env.NEXT_PUBLIC_GRAPHQL_URL;
+  if (!url) url = chainConfig().endpoints.graphql;
+  if (!url) url = 'http://localhost:3000/v1/graphql';
+  return url;
+}
 
 export const useStaking = (
   rewards: RewardsType,
@@ -66,20 +74,15 @@ export const useStaking = (
     // helper function to get rest of the staking items
     // if it is over the default limit
     const getStakeByPage = async (page: number, query: string) => {
-      const { data } = await axios.post(
-        process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-          chainConfig().endpoints.graphql ||
-          'http://localhost:3000/v1/graphql',
-        {
-          variables: {
-            address: (router?.query?.address as string) ?? '',
-            offset: page * LIMIT,
-            limit: LIMIT,
-            pagination: false,
-          },
-          query,
-        }
-      );
+      const { data } = await axios.post(getUrl(), {
+        variables: {
+          address: (router?.query?.address as string) ?? '',
+          offset: page * LIMIT,
+          limit: LIMIT,
+          pagination: false,
+        },
+        query,
+      });
       return data;
     };
 
@@ -88,18 +91,13 @@ export const useStaking = (
     // =====================================
     const getDelegations = async () => {
       try {
-        const { data } = await axios.post(
-          process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-            chainConfig().endpoints.graphql ||
-            'http://localhost:3000/v1/graphql',
-          {
-            variables: {
-              address: (router?.query?.address as string) ?? '',
-              limit: LIMIT,
-            },
-            query: accountDelegationsDocument,
-          }
-        );
+        const { data } = await axios.post(getUrl(), {
+          variables: {
+            address: (router?.query?.address as string) ?? '',
+            limit: LIMIT,
+          },
+          query: accountDelegationsDocument,
+        });
         const count = data?.data?.delegations?.pagination?.total ?? 0;
         const allDelegations = R.pathOr<
           NonNullable<typeof data['data']['delegations']['delegations']>
@@ -144,18 +142,13 @@ export const useStaking = (
     // =====================================
     const getRedelegations = async () => {
       try {
-        const { data } = await axios.post(
-          process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-            chainConfig().endpoints.graphql ||
-            'http://localhost:3000/v1/graphql',
-          {
-            variables: {
-              address: (router?.query?.address as string) ?? '',
-              limit: LIMIT,
-            },
-            query: accountRedelegationsDocument,
-          }
-        );
+        const { data } = await axios.post(getUrl(), {
+          variables: {
+            address: (router?.query?.address as string) ?? '',
+            limit: LIMIT,
+          },
+          query: accountRedelegationsDocument,
+        });
         const count = data?.data?.redelegations?.pagination?.total ?? 0;
         const allData = R.pathOr<
           NonNullable<typeof data['data']['redelegations']['redelegations']>
@@ -203,18 +196,13 @@ export const useStaking = (
     // =====================================
     const getUnbondings = async () => {
       try {
-        const { data } = await axios.post(
-          process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-            chainConfig().endpoints.graphql ||
-            'http://localhost:3000/v1/graphql',
-          {
-            variables: {
-              address: (router?.query?.address as string) ?? '',
-              limit: LIMIT,
-            },
-            query: accountUndelegationsDocument,
-          }
-        );
+        const { data } = await axios.post(getUrl(), {
+          variables: {
+            address: (router?.query?.address as string) ?? '',
+            limit: LIMIT,
+          },
+          query: accountUndelegationsDocument,
+        });
         const count = data?.data?.undelegations?.pagination?.total ?? 0;
         const allData = R.pathOr<
           NonNullable<typeof data['data']['undelegations']['undelegations']>

--- a/packages/ui/src/screens/account_details/components/staking/hooks.ts
+++ b/packages/ui/src/screens/account_details/components/staking/hooks.ts
@@ -69,7 +69,7 @@ export const useStaking = (
             reward: rewards[validator],
           };
         })
-        .sort((a, b) => (Big(a.amount.value).gt(b.amount.value) ? -1 : 1));
+        .sort((a, b) => (Big(a.amount?.value).gt(b.amount?.value) ? -1 : 1));
 
     // helper function to get rest of the staking items
     // if it is over the default limit

--- a/packages/ui/src/screens/account_details/utils.tsx
+++ b/packages/ui/src/screens/account_details/utils.tsx
@@ -1,3 +1,4 @@
+import chainConfig from '@/chainConfig';
 import {
   AccountBalancesDocument,
   AccountCommissionDocument,
@@ -9,7 +10,12 @@ import {
 import { toValidatorAddress } from '@/utils/prefix_convert';
 import axios from 'axios';
 
-import chainConfig from '@/chainConfig';
+function getUrl() {
+  let url = process.env.NEXT_PUBLIC_GRAPHQL_URL;
+  if (!url) url = chainConfig().endpoints.graphql;
+  if (!url) url = 'http://localhost:3000/v1/graphql';
+  return url;
+}
 
 export const fetchCommission = async (address: string) => {
   const defaultReturnValue = {
@@ -18,17 +24,12 @@ export const fetchCommission = async (address: string) => {
     },
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          validatorAddress: toValidatorAddress(address),
-        },
-        query: AccountCommissionDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        validatorAddress: toValidatorAddress(address),
+      },
+      query: AccountCommissionDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;
@@ -42,17 +43,12 @@ export const fetchAccountWithdrawalAddress = async (address: string) => {
     },
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          address,
-        },
-        query: AccountWithdrawalAddressDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        address,
+      },
+      query: AccountWithdrawalAddressDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;
@@ -66,17 +62,12 @@ export const fetchAvailableBalances = async (address: string) => {
     },
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          address,
-        },
-        query: AccountBalancesDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        address,
+      },
+      query: AccountBalancesDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;
@@ -90,17 +81,12 @@ export const fetchDelegationBalance = async (address: string) => {
     },
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          address,
-        },
-        query: AccountDelegationBalanceDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        address,
+      },
+      query: AccountDelegationBalanceDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;
@@ -114,17 +100,12 @@ export const fetchUnbondingBalance = async (address: string) => {
     },
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          address,
-        },
-        query: AccountUnbondingBalanceDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        address,
+      },
+      query: AccountUnbondingBalanceDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;
@@ -136,17 +117,12 @@ export const fetchRewards = async (address: string) => {
     delegationRewards: [],
   };
   try {
-    const { data } = await axios.post(
-      process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-        chainConfig().endpoints.graphql ||
-        'http://localhost:3000/v1/graphql',
-      {
-        variables: {
-          address,
-        },
-        query: AccountDelegationRewardsDocument,
-      }
-    );
+    const { data } = await axios.post(getUrl(), {
+      variables: {
+        address,
+      },
+      query: AccountDelegationRewardsDocument,
+    });
     return data?.data ?? defaultReturnValue;
   } catch (error) {
     return defaultReturnValue;

--- a/packages/ui/src/screens/app/hooks.ts
+++ b/packages/ui/src/screens/app/hooks.ts
@@ -2,6 +2,7 @@ import chainConfig from '@/chainConfig';
 import { init } from '@socialgouv/matomo-next';
 import * as jdenticon from 'jdenticon';
 import useTranslation from 'next-translate/useTranslation';
+
 import { useEffect } from 'react';
 
 export const useApp = () => {
@@ -11,13 +12,14 @@ export const useApp = () => {
   const { lang } = useTranslation();
 
   useEffect(() => {
-    const MATOMO_URL = process.env.NEXT_PUBLIC_MATOMO_URL || chainConfig().marketing.matomoURL;
-    const MATOMO_SITE_ID =
-      process.env.NEXT_PUBLIC_MATOMO_SITE_ID || chainConfig().marketing.matomoSiteID;
-    if (MATOMO_URL && MATOMO_SITE_ID) {
+    let matomoUrl = process.env.NEXT_PUBLIC_MATOMO_URL;
+    if (!matomoUrl) matomoUrl = chainConfig().marketing.matomoURL;
+    let matomoSiteId = process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
+    if (!matomoSiteId) matomoSiteId = chainConfig().marketing.matomoSiteID;
+    if (matomoUrl && matomoSiteId) {
       init({
-        url: MATOMO_URL,
-        siteId: MATOMO_SITE_ID,
+        url: matomoUrl,
+        siteId: matomoSiteId,
       });
     }
     // jdenticon theme

--- a/packages/ui/src/screens/home/components/consensus/hooks.ts
+++ b/packages/ui/src/screens/home/components/consensus/hooks.ts
@@ -2,9 +2,18 @@ import chainConfig from '@/chainConfig';
 import { hexToBech32 } from '@/utils/hex_to_bech32';
 import { GRAPHQL_TRANSPORT_WS_PROTOCOL, MessageType, stringifyMessage } from 'graphql-ws';
 import WebSocket from 'isomorphic-ws';
+
 import numeral from 'numeral';
 import * as R from 'ramda';
 import { useEffect, useState } from 'react';
+
+function getWs() {
+  let ws = process.env.NEXT_PUBLIC_RPC_WEBSOCKET;
+  if (!ws) ws = chainConfig().endpoints.publicRpcWebsocket;
+  if (!ws) ws = chainConfig().endpoints.graphqlWebsocket;
+  if (!ws) ws = 'ws://localhost:3000/websocket';
+  return ws;
+}
 
 export const useConsensus = () => {
   const [state, setState] = useState<{
@@ -82,13 +91,7 @@ export const useConsensus = () => {
     };
 
     function connect() {
-      client = new WebSocket(
-        process.env.NEXT_PUBLIC_RPC_WEBSOCKET ||
-          chainConfig().endpoints.publicRpcWebsocket ||
-          chainConfig().endpoints.graphqlWebsocket ||
-          'ws://localhost:3000/websocket',
-        GRAPHQL_TRANSPORT_WS_PROTOCOL
-      );
+      client = new WebSocket(getWs(), GRAPHQL_TRANSPORT_WS_PROTOCOL);
 
       client.onopen = () => {
         client.send(JSON.stringify(stepHeader));

--- a/packages/ui/src/screens/home/components/consensus/hooks.ts
+++ b/packages/ui/src/screens/home/components/consensus/hooks.ts
@@ -2,7 +2,6 @@ import chainConfig from '@/chainConfig';
 import { hexToBech32 } from '@/utils/hex_to_bech32';
 import { GRAPHQL_TRANSPORT_WS_PROTOCOL, MessageType, stringifyMessage } from 'graphql-ws';
 import WebSocket from 'isomorphic-ws';
-
 import numeral from 'numeral';
 import * as R from 'ramda';
 import { useEffect, useState } from 'react';
@@ -117,9 +116,9 @@ export const useConsensus = () => {
         }, 1000);
       };
 
-      client.onerror = (err: WebSocket.ErrorEvent) => {
+      client.onerror = (err: unknown) => {
         client.close();
-        console.error(`Socket encountered error: ${err.message}Closing socket`);
+        console.error('Socket encountered error: Closing socket', err);
       };
 
       function enqueuePing() {

--- a/packages/ui/src/screens/profile_details/hooks.ts
+++ b/packages/ui/src/screens/profile_details/hooks.ts
@@ -29,7 +29,7 @@ export const useProfileDetails = () => {
       const desmosProfile = formatDesmosProfile(data);
       handleSetState({
         loading: false,
-        exists: !!data.profile.length,
+        exists: !!data.profile?.length,
         desmosProfile,
       });
       return desmosProfile;

--- a/packages/ui/src/screens/proposal_details/components/deposits/components/desktop/index.tsx
+++ b/packages/ui/src/screens/proposal_details/components/deposits/components/desktop/index.tsx
@@ -28,10 +28,12 @@ const Desktop: React.FC<{
       ) : (
         <>-</>
       ),
-      amount: `${formatNumber(
-        x.amount.value,
-        x.amount.exponent
-      )} ${x.amount.displayDenom.toUpperCase()}`,
+      amount: x.amount
+        ? `${formatNumber(
+            x.amount.value,
+            x.amount.exponent
+          )} ${x.amount.displayDenom.toUpperCase()}`
+        : '',
       time: formatDayJs(dayjs.utc(x.timestamp), dateFormat),
     })) ?? [];
 

--- a/packages/ui/src/screens/proposal_details/components/deposits/components/mobile/index.tsx
+++ b/packages/ui/src/screens/proposal_details/components/deposits/components/mobile/index.tsx
@@ -26,10 +26,12 @@ const Mobile: React.FC<{
       ) : (
         <>-</>
       ),
-      amount: `${formatNumber(
-        x.amount.value,
-        x.amount.exponent
-      )} ${x.amount.displayDenom.toUpperCase()}`,
+      amount: x.amount
+        ? `${formatNumber(
+            x.amount.value,
+            x.amount.exponent
+          )} ${x.amount.displayDenom.toUpperCase()}`
+        : '',
       time: formatDayJs(dayjs.utc(x.timestamp), dateFormat),
     })) ?? [];
 

--- a/packages/ui/src/screens/validator_details/components/staking/components/delegations/components/desktop/index.tsx
+++ b/packages/ui/src/screens/validator_details/components/staking/components/delegations/components/desktop/index.tsx
@@ -25,10 +25,12 @@ const Desktop: React.FC<{
           imageUrl={x.address.imageUrl}
         />
       ),
-      amount: `${formatNumber(
-        x.amount.value,
-        x.amount.exponent
-      )} ${x.amount.displayDenom.toUpperCase()}`,
+      amount: x.amount
+        ? `${formatNumber(
+            x.amount.value,
+            x.amount.exponent
+          )} ${x.amount.displayDenom.toUpperCase()}`
+        : '',
     })) ?? [];
 
   return (

--- a/packages/ui/src/screens/validator_details/components/staking/components/delegations/components/mobile/index.tsx
+++ b/packages/ui/src/screens/validator_details/components/staking/components/delegations/components/mobile/index.tsx
@@ -36,8 +36,8 @@ const Mobile: React.FC<{
                 {t('amount')}
               </Typography>
               <Typography variant="body1" className="value">
-                {formatNumber(x.amount.value, x.amount.exponent)}{' '}
-                {x.amount.displayDenom.toUpperCase()}
+                {x.amount ? formatNumber(x.amount.value, x.amount.exponent) : ''}{' '}
+                {x.amount?.displayDenom.toUpperCase()}
               </Typography>
             </div>
           </div>

--- a/packages/ui/src/screens/validator_details/components/staking/components/redelegations/components/desktop/index.tsx
+++ b/packages/ui/src/screens/validator_details/components/staking/components/redelegations/components/desktop/index.tsx
@@ -30,10 +30,12 @@ const Desktop: React.FC<{
         />
       ),
       to: <AvatarName address={x.to.address} imageUrl={x.to.imageUrl} name={x.to.name} />,
-      amount: `${formatNumber(
-        x.amount.value,
-        x.amount.exponent
-      )} ${x.amount.displayDenom.toUpperCase()}`,
+      amount: x.amount
+        ? `${formatNumber(
+            x.amount.value,
+            x.amount.exponent
+          )} ${x.amount.displayDenom.toUpperCase()}`
+        : '',
       completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
     })) ?? [];
 

--- a/packages/ui/src/screens/validator_details/components/staking/components/redelegations/components/mobile/index.tsx
+++ b/packages/ui/src/screens/validator_details/components/staking/components/redelegations/components/mobile/index.tsx
@@ -28,10 +28,12 @@ const Mobile: React.FC<{
         />
       ),
       to: <AvatarName address={x.to.address} imageUrl={x.to.imageUrl} name={x.to.name} />,
-      amount: `${formatNumber(
-        x.amount.value,
-        x.amount.exponent
-      )} ${x.amount.displayDenom.toUpperCase()}`,
+      amount: x.amount
+        ? `${formatNumber(
+            x.amount.value,
+            x.amount.exponent
+          )} ${x.amount.displayDenom.toUpperCase()}`
+        : '',
       completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
     })) ?? [];
 

--- a/packages/ui/src/screens/validator_details/components/staking/components/unbondings/components/desktop/index.tsx
+++ b/packages/ui/src/screens/validator_details/components/staking/components/unbondings/components/desktop/index.tsx
@@ -29,10 +29,12 @@ const Desktop: React.FC<{
           name={x.address.name}
         />
       ),
-      amount: `${formatNumber(
-        x.amount.value,
-        x.amount.exponent
-      )} ${x.amount.displayDenom.toUpperCase()}`,
+      amount: x.amount
+        ? `${formatNumber(
+            x.amount.value,
+            x.amount.exponent
+          )} ${x.amount.displayDenom.toUpperCase()}`
+        : '',
       completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
     })) ?? [];
 

--- a/packages/ui/src/screens/validator_details/components/staking/components/unbondings/components/mobile/index.tsx
+++ b/packages/ui/src/screens/validator_details/components/staking/components/unbondings/components/mobile/index.tsx
@@ -27,10 +27,12 @@ const Mobile: React.FC<{
           name={x.address.name}
         />
       ),
-      amount: `${formatNumber(
-        x.amount.value,
-        x.amount.exponent
-      )} ${x.amount.displayDenom.toUpperCase()}`,
+      amount: x.amount
+        ? `${formatNumber(
+            x.amount.value,
+            x.amount.exponent
+          )} ${x.amount.displayDenom.toUpperCase()}`
+        : '',
       completionTime: formatDayJs(dayjs.utc(x.completionTime), dateFormat),
     })) ?? [];
 

--- a/packages/ui/src/screens/validator_details/components/staking/hooks.ts
+++ b/packages/ui/src/screens/validator_details/components/staking/hooks.ts
@@ -14,6 +14,7 @@ import { getDenom } from '@/utils/get_denom';
 import Tabs from '@material-ui/core/Tabs';
 import axios from 'axios';
 import Big from 'big.js';
+
 import { useRouter } from 'next/router';
 import * as R from 'ramda';
 import { ComponentProps, useCallback, useEffect, useState } from 'react';
@@ -81,6 +82,13 @@ type DataUndelegations = {
   };
 };
 
+function getUrl() {
+  let url = process.env.NEXT_PUBLIC_GRAPHQL_URL;
+  if (!url) url = chainConfig().endpoints.graphql;
+  if (!url) url = 'http://localhost:3000/v1/graphql';
+  return url;
+}
+
 export const useStaking = () => {
   const router = useRouter();
   const [state, setState] = useState<StakingState>({
@@ -128,20 +136,15 @@ export const useStaking = () => {
     // helper function to get rest of the staking items
     // if it is over the default limit
     const getStakeByPage = async (page: number, query: string) => {
-      const { data } = await axios.post(
-        process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-          chainConfig().endpoints.graphql ||
-          'http://localhost:3000/v1/graphql',
-        {
-          variables: {
-            validatorAddress: router?.query?.address ?? '',
-            offset: page * LIMIT,
-            limit: LIMIT,
-            pagination: false,
-          },
-          query,
-        }
-      );
+      const { data } = await axios.post(getUrl(), {
+        variables: {
+          validatorAddress: router?.query?.address ?? '',
+          offset: page * LIMIT,
+          limit: LIMIT,
+          pagination: false,
+        },
+        query,
+      });
       return data;
     };
 
@@ -179,18 +182,13 @@ export const useStaking = () => {
     // =====================================
     const getDelegations = async () => {
       try {
-        const { data } = await axios.post<DataDelegations>(
-          process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-            chainConfig().endpoints.graphql ||
-            'http://localhost:3000/v1/graphql',
-          {
-            variables: {
-              validatorAddress: router?.query?.address ?? '',
-              limit: LIMIT,
-            },
-            query: ValidatorDelegationsDocument,
-          }
-        );
+        const { data } = await axios.post<DataDelegations>(getUrl(), {
+          variables: {
+            validatorAddress: router?.query?.address ?? '',
+            limit: LIMIT,
+          },
+          query: ValidatorDelegationsDocument,
+        });
         const count = data?.data?.delegations?.pagination?.total ?? 0;
         const allDelegations = R.pathOr<
           NonNullable<typeof data['data']['delegations']['delegations']>
@@ -233,18 +231,13 @@ export const useStaking = () => {
     // =====================================
     const getRedelegations = async () => {
       try {
-        const { data } = await axios.post<DataRedelegations>(
-          process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-            chainConfig().endpoints.graphql ||
-            'http://localhost:3000/v1/graphql',
-          {
-            variables: {
-              validatorAddress: router?.query?.address ?? '',
-              limit: LIMIT,
-            },
-            query: ValidatorRedelegationsDocument,
-          }
-        );
+        const { data } = await axios.post<DataRedelegations>(getUrl(), {
+          variables: {
+            validatorAddress: router?.query?.address ?? '',
+            limit: LIMIT,
+          },
+          query: ValidatorRedelegationsDocument,
+        });
         const count = data?.data?.redelegations?.pagination?.total ?? 0;
         const allData = R.pathOr<
           NonNullable<typeof data['data']['redelegations']['redelegations']>
@@ -290,18 +283,13 @@ export const useStaking = () => {
     // =====================================
     const getUnbondings = async () => {
       try {
-        const { data } = await axios.post<DataUndelegations>(
-          process.env.NEXT_PUBLIC_GRAPHQL_URL ||
-            chainConfig().endpoints.graphql ||
-            'http://localhost:3000/v1/graphql',
-          {
-            variables: {
-              validatorAddress: router?.query?.address ?? '',
-              limit: LIMIT,
-            },
-            query: ValidatorUndelegationsDocument,
-          }
-        );
+        const { data } = await axios.post<DataUndelegations>(getUrl(), {
+          variables: {
+            validatorAddress: router?.query?.address ?? '',
+            limit: LIMIT,
+          },
+          query: ValidatorUndelegationsDocument,
+        });
         const count = data?.data?.undelegations?.pagination?.total ?? 0;
         const allData = R.pathOr<
           NonNullable<typeof data['data']['undelegations']['undelegations']>

--- a/packages/ui/src/screens/validator_details/components/staking/hooks.ts
+++ b/packages/ui/src/screens/validator_details/components/staking/hooks.ts
@@ -158,7 +158,7 @@ export const useStaking = () => {
             amount: formatToken(delegation.amount, delegation.denom),
           };
         })
-        .sort((a, b) => (Big(a.amount.value).gt(b.amount.value) ? -1 : 1));
+        .sort((a, b) => (Big(a.amount?.value).gt(b.amount?.value) ? -1 : 1));
 
     const formatRedelegations = (data: Array<Redelegations>) => {
       const results: RedelegationType[] = [];

--- a/turbo.json
+++ b/turbo.json
@@ -14,11 +14,11 @@
         "NEXT_PUBLIC_MATOMO_URL",
         "NEXT_PUBLIC_RPC_WEBSOCKET",
         "NEXT_PUBLIC_SENTRY_DSN",
-        "SENTRY_URL",
+        "SENTRY_AUTH_TOKEN",
+        "SENTRY_ENVIRONMENT",
         "SENTRY_ORG",
         "SENTRY_PROJECT",
-        "SENTRY_ENVIRONMENT",
-        "SENTRY_AUTH_TOKEN"
+        "SENTRY_URL"
       ]
     },
     "clean": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11525,9 +11525,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recharts@npm:^2.1.16":
-  version: 2.1.16
-  resolution: "recharts@npm:2.1.16"
+"recharts@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "recharts@npm:2.2.0"
   dependencies:
     "@types/d3-interpolate": ^2.0.0
     "@types/d3-scale": ^3.0.0
@@ -11547,7 +11547,7 @@ __metadata:
     prop-types: ^15.6.0
     react: ^16.0.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 3ca97570e136da9f0383aa82a9aad6954307bda08b221e56c61e00e08185324c6660399bd5cdd609b79323725b68cd389b55ee0e039cfbedbe9f41858a2fec52
+  checksum: 901887b2459305c6dec20b413926c531a84f108bd4cf9653d0e0234df069ae85af5cca859be247fce0fc6a41f704a1c369c71fdf7792de96ef741b1b33eed1d0
   languageName: node
   linkType: hard
 
@@ -13358,7 +13358,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -13700,7 +13700,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -13807,7 +13807,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -13914,7 +13914,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14021,7 +14021,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14128,7 +14128,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14235,7 +14235,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14342,7 +14342,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14449,7 +14449,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14556,7 +14556,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14663,7 +14663,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14770,7 +14770,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14877,7 +14877,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -14984,7 +14984,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15091,7 +15091,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15198,7 +15198,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15305,7 +15305,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15412,7 +15412,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15519,7 +15519,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15626,7 +15626,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15733,7 +15733,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15840,7 +15840,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -15947,7 +15947,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -16068,7 +16068,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2
@@ -16175,7 +16175,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.7
     react-window: ^1.8.8
     react-window-infinite-loader: ^1.0.8
-    recharts: ^2.1.16
+    recharts: ^2.2.0
     recoil: ^0.7.6
     shared-utils: "*"
     sharp: ^0.31.2


### PR DESCRIPTION
## Description

Closes: #1064

- also include various bug fixes

Related disucssion: vercel/next.js#34894

Trade-offs:
pros:
- No config on client side state which require huge amount of rewrite to our current codebase (to put all config on hook)
- Not depend on the legacy NextJs Runtime Configuration which require getInitialProps or getServerSideProps on each page.

cons:
- Will not work on `next dev` or `next start` (normally), variables can inject once, only work in docker environment.
- Will not work on some syntax `process.env.NEXT_PUBLIC_MYVAR || 'none empty'` will compile to `process.env.NEXT_PUBLIC_MYVAR`
- A hacks way which may break in future NextJS release


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] ran linting
- [X] wrote tests where necessary
- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] targeted the correct branch
- [X] provided a link to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed
- [X] added an entry to the `CHANGELOG.md` file
