### PR TITLE
feat: Set codes as default tab for WASMContract [web-comdex]

### DIFF
--- a/.changeset/three-crabs-invite.md
+++ b/.changeset/three-crabs-invite.md
@@ -1,0 +1,5 @@
+---
+'web-comdex': patch
+---
+
+feat: set codes as the default tab for WASMContract page

--- a/apps/web-comdex/src/screens/wasmContracts/index.tsx
+++ b/apps/web-comdex/src/screens/wasmContracts/index.tsx
@@ -33,7 +33,7 @@ import {
 const WasmContracts = () => {
   const { t } = useTranslation('wasm_contracts');
   const { classes, cx, theme } = useStyles();
-  const [tab, setTab] = useState(0);
+  const [tab, setTab] = useState(1); // 0: contracts, 1: codes (default), since there's no contract yet
   const handleTabChange = (_: SyntheticEvent, newValue: number) => setTab(newValue);
 
   const title = t('wasmContracts');


### PR DESCRIPTION
## Description

- Set codes as default tab for WASMContract

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] ran linting via `yarn lint`
- [X] wrote tests where necessary
- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] targeted the correct branch
- [X] provided a link to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed
- [X] added a changeset via [`yarn && yarn changeset`](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
